### PR TITLE
fix unicodeEncodeErrors

### DIFF
--- a/plexlibrary/plexlibrary.py
+++ b/plexlibrary/plexlibrary.py
@@ -17,7 +17,8 @@ Credit:
 
 import argparse
 import sys
-
+reload(sys)
+sys.setdefaultencoding('utf8')
 import recipes
 from recipe import Recipe
 


### PR DESCRIPTION
Allow running as cron job, stopping:

UnicodeEncodeError: 'ascii' codec can't encode character

errors