### PR TITLE
Playlist option + code cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@ Python-PlexLibrary
 ==================
 
 Python command line utility for creating and maintaining dynamic Plex
-libraries based on "recipes".
+libraries and playlists based on "recipes".
 
-E.g. Create a library consisting of all movies or tv shows in a Trakt_ list or
+E.g. Create a library or playlist consisting of all movies or tv shows in a Trakt_ list or
 on an IMDb_ chart that exist in your main library, and set the sort titles
-accordingly.
+accordingly (sort only available for libraries).
 
 .. _Trakt: https://trakt.tv/
 .. _IMDb: https://imdb.com/

--- a/plexlibrary/plexlibrary.py
+++ b/plexlibrary/plexlibrary.py
@@ -42,6 +42,9 @@ def main():
         help='list available recipes')
     parser.add_argument(
         '-s', '--sort-only', action='store_true', help='only sort the library')
+    parser.add_argument(
+        '-p', '--playlists', action='store_true', help='make playlists rather than libraries'
+    )
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -57,7 +60,7 @@ def main():
         list_recipes()
         sys.exit(1)
 
-    r = Recipe(args.recipe)
+    r = Recipe(recipe_name=args.recipe, use_playlists=args.playlists)
     r.run(args.sort_only)
 
     print("Done!")

--- a/plexlibrary/plexutils.py
+++ b/plexlibrary/plexutils.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import plexapi.server
+import plexapi.media
 import requests
+from urllib.parse import urlencode
+from typing import List
 
 
 class Plex(object):
@@ -35,6 +38,59 @@ class Plex(object):
         url = '{base_url}/library/sections'.format(base_url=self.baseurl)
         requests.post(url, headers=headers, params=params)
 
+    def create_new_playlist(self, playlist_name, items: List[plexapi.media.Media]):
+        self.server.createPlaylist(title=playlist_name, items=items)
+
+    def _get_existing_playlist(self, playlist_name):
+        for playlist in self.server.playlists():
+            if playlist.title == playlist_name:
+                return playlist
+        return None
+
+    def get_playlist_items(self, playlist_name):
+        playlist = self._get_existing_playlist(playlist_name=playlist_name)
+        if playlist:
+            return playlist.items()
+        return []
+
+    def add_to_playlist(self, playlist_name, items: List[plexapi.media.Media]):
+        playlist = self._get_existing_playlist(playlist_name=playlist_name)
+        if playlist:
+            playlist.addItems(items=items)
+        else:
+            self.create_new_playlist(playlist_name=playlist_name, items=items)
+
+    def remove_from_playlist(self, playlist_name, items: List[plexapi.media.Media]):
+        playlist = self._get_existing_playlist(playlist_name=playlist_name)
+        if playlist:
+            for item in items:
+                playlist.removeItem(item=item)
+
+    def reset_playlist(self, playlist_name, new_items: List[plexapi.media.Media]):
+        """
+        Delete old playlist and remake it with new items
+        :param new_items: list of Media objects
+        :param playlist_name:
+        :return:
+        """
+        playlist = self._get_existing_playlist(playlist_name=playlist_name)
+        if playlist:
+            playlist.delete()
+        self.create_new_playlist(playlist_name=playlist_name, items=new_items)
+
+    def _get_section_by_name(self, section_name):
+        try:
+            return self.server.library.section(title=section_name)
+        except:
+            pass
+        return None
+
+    def get_library_paths(self, library_name):
+        section = self._get_section_by_name(section_name=library_name)
+        if section:
+            return section.locations
+        return []
+
     def set_sort_title(self, library_key, rating_key, number, title,
                        library_type, title_format, visible=False):
         headers = {'X-Plex-Token': self.token}
@@ -59,5 +115,5 @@ class Plex(object):
             params['title.locked'] = 0
 
         url = "{base_url}/library/sections/{library}/all".format(
-                base_url=self.baseurl, library=library_key)
+            base_url=self.baseurl, library=library_key)
         requests.put(url, headers=headers, params=params)

--- a/plexlibrary/recipe.py
+++ b/plexlibrary/recipe.py
@@ -28,8 +28,9 @@ class Recipe(object):
     tmdb = None
     tvdb = None
 
-    def __init__(self, recipe_name, sort_only=False, config_file=None):
+    def __init__(self, recipe_name, sort_only=False, config_file=None, use_playlists=False):
         self.recipe_name = recipe_name
+        self.use_playlists = use_playlists
 
         self.config = ConfigParser(config_file)
         self.recipe = RecipeParser(recipe_name)
@@ -69,12 +70,10 @@ class Recipe(object):
 
         self.imdb = imdbutils.IMDb(self.tmdb, self.tvdb)
 
-    def _run(self):
+    def _get_trakt_lists(self):
         item_list = []  # TODO Replace with dict, scrap item_ids?
         item_ids = []
-        force_imdb_id_match = False
 
-        # Get the trakt lists
         for url in self.recipe['source_list_urls']:
             if 'api.trakt.tv' in url:
                 (item_list, item_ids) = self.trakt.add_items(
@@ -95,8 +94,9 @@ class Recipe(object):
             else:
                 print(u"Warning: TMDd API key is required "
                       u"for weighted sorting")
+        return item_list, item_ids
 
-        # Get list of items from the Plex server
+    def _get_plex_libraries(self):
         source_libraries = []
         for library_config in self.source_library_config:
             print(u"Trying to match with items from the '{}' library ".format(
@@ -113,8 +113,9 @@ class Recipe(object):
                 source_library.ALLOWED_FILTERS += ('guid',)
 
             source_libraries.append(source_library)
+        return source_libraries
 
-        # Create a list of matching items
+    def _get_matching_items(self, source_libraries, item_list):
         matching_items = []
         missing_items = []
         matching_total = 0
@@ -123,7 +124,7 @@ class Recipe(object):
 
         for i, item in enumerate(item_list):
             match = False
-            if max_count > 0 and matching_total >= max_count:
+            if 0 < max_count <= matching_total:
                 nonmatching_idx.append(i)
                 continue
             res = []
@@ -178,7 +179,9 @@ class Recipe(object):
             for i in reversed(nonmatching_idx):
                 del item_list[i]
 
-        # Create symlinks for all items in your library on the trakt watched
+        return matching_items, missing_items, matching_total, nonmatching_idx, max_count
+
+    def _create_symbolic_links(self, matching_items, matching_total):
         print(u"Creating symlinks for {count} matching items in the "
               u"library...".format(count=matching_total))
 
@@ -203,7 +206,7 @@ class Recipe(object):
 
                     folder_name = ''
                     for library_config in self.source_library_config:
-                        for f in library_config['folders']:
+                        for f in self.plex.get_library_paths(library_name=library_config['name']):
                             f = os.path.abspath(f)
                             if old_path.lower().startswith(f.lower()):
                                 folder_name = os.path.relpath(old_path, f)
@@ -274,7 +277,7 @@ class Recipe(object):
 
                         folder_name = ''
                         for library_config in self.source_library_config:
-                            for f in library_config['folders']:
+                            for f in self.plex.get_library_paths(library_name=library_config['name']):
                                 if old_path.lower().startswith(f.lower()):
                                     old_path = os.path.join(f,
                                                             old_path.replace(
@@ -314,9 +317,8 @@ class Recipe(object):
         for item in new_items:
             print(u"{title} ({year})".format(title=item.title, year=item.year))
 
+    def _verify_new_library_and_get_items(self, create_if_not_found=False):
         # Check if the new library exists in Plex
-        print(u"Creating the '{}' library in Plex...".format(
-            self.recipe['new_library']['name']))
         try:
             new_library = self.plex.server.library.section(
                 self.recipe['new_library']['name'])
@@ -324,12 +326,17 @@ class Recipe(object):
 
             new_library.update()
         except plexapi.exceptions.NotFound:
-            self.plex.create_new_library(
-                self.recipe['new_library']['name'],
-                self.recipe['new_library']['folder'],
-                self.library_type)
-            new_library = self.plex.server.library.section(
-                self.recipe['new_library']['name'])
+            if create_if_not_found:
+                self.plex.create_new_library(
+                    self.recipe['new_library']['name'],
+                    self.recipe['new_library']['folder'],
+                    self.library_type)
+                new_library = self.plex.server.library.section(
+                    self.recipe['new_library']['name'])
+            else:
+                raise Exception("Library '{library}' does not exist".format(
+                    library=self.recipe['new_library']['name']))
+
 
         # Wait for metadata to finish downloading before continuing
         print(u"Waiting for metadata to finish downloading...")
@@ -343,11 +350,11 @@ class Recipe(object):
         # Retrieve a list of items from the new library
         print(u"Retrieving a list of items from the '{library}' library in "
               u"Plex...".format(library=self.recipe['new_library']['name']))
-        all_new_items = new_library.all()
+        return new_library, new_library.all()
 
-        # Create a dictionary of {imdb_id: item}
+    def _get_imdb_dict(self, media_items, item_ids, force_match=False):
         imdb_map = {}
-        for m in all_new_items:
+        for m in media_items:
             imdb_id = None
             tmdb_id = None
             tvdb_id = None
@@ -368,7 +375,7 @@ class Recipe(object):
                 imdb_map['tmdb' + str(tmdb_id)] = m
             elif tvdb_id and ('tvdb' + str(tvdb_id)) in item_ids:
                 imdb_map['tvdb' + str(tvdb_id)] = m
-            elif force_imdb_id_match:
+            elif force_match:
                 # Only IMDB ID found for some items
                 if tmdb_id:
                     imdb_id = self.tmdb.get_imdb_id(tmdb_id)
@@ -380,8 +387,9 @@ class Recipe(object):
                     imdb_map[m.ratingKey] = m
             else:
                 imdb_map[m.ratingKey] = m
+        return imdb_map
 
-        # Modify the sort titles
+    def _modify_sort_titles_and_cleanup(self, item_list, imdb_map, new_library, sort_only=False):
         if self.recipe['new_library']['sort']:
             print(u"Setting the sort titles for the '{}' library...".format(
                 self.recipe['new_library']['name']))
@@ -419,10 +427,17 @@ class Recipe(object):
                         self.recipe['new_library']['sort_title']['format'],
                         self.recipe['new_library']['sort_title']['visible']
                     )
+                    if sort_only:
+                        self._pop_imdb_map(imdb_map=imdb_map, new_library=new_library)
+                        return True
+        if self.recipe['new_library']['remove_from_library'] or self.recipe['new_library'].get('remove_old', False):
+            # Remove old items that no longer qualify
+            self._remove_old_items_from_library(imdb_map=imdb_map)
+            all_new_items = self._cleanup_new_library(new_library=new_library)
+            self._pop_imdb_map(imdb_map=imdb_map, new_library=new_library)
+        return all_new_items
 
-        if self.recipe['new_library']['remove_from_library'] \
-                or self.recipe['new_library'].get('remove_old', False):
-            # Remove items from the new library which no longer qualify
+    def _remove_old_items_from_library(self, imdb_map):
             print(u"Removing symlinks for items "
                   "which no longer qualify ".format(
                 library=self.recipe['new_library']['name']))
@@ -533,159 +548,78 @@ class Recipe(object):
                 print(u"{title} ({year})".format(title=item.title,
                                                  year=item.year))
 
-            # Scan the library to clean up the deleted items
-            print(u"Scanning the '{library}' library...".format(
-                library=self.recipe['new_library']['name']))
-            new_library.update()
-            time.sleep(10)
-            new_library = self.plex.server.library.section(
-                self.recipe['new_library']['name'])
-            while new_library.refreshing:
-                time.sleep(5)
-                new_library = self.plex.server.library.section(
-                    self.recipe['new_library']['name'])
-            new_library.emptyTrash()
-            all_new_items = new_library.all()
-
-        if not self.recipe['new_library']['remove_from_library'] \
-                or self.recipe['new_library'].get('remove_old', False):
-            while imdb_map:
-                imdb_id, item = imdb_map.popitem()
-                i += 1
-                print(u"{} {} ({})".format(i, item.title, item.year))
-                self.plex.set_sort_title(
-                    new_library.key, item.ratingKey, i, item.title,
-                    self.library_type,
-                    self.recipe['new_library']['sort_title']['format'],
-                    self.recipe['new_library']['sort_title']['visible'])
-
-        return missing_items, len(all_new_items)
-
-    def _run_sort_only(self):
-        item_list = []
-        item_ids = []
-        force_imdb_id_match = False
-
-        # Get the trakt lists
-        for url in self.recipe['source_list_urls']:
-            if 'api.trakt.tv' in url:
-                (item_list, item_ids) = self.trakt.add_items(
-                    self.library_type, url, item_list, item_ids,
-                    self.recipe['new_library']['max_age'] or 0)
-            else:
-                raise Exception("Unsupported source list: {url}".format(
-                    url=url))
-
-        if self.recipe['weighted_sorting']['enabled']:
-            if self.config['tmdb']['api_key']:
-                print(u"Getting data from TMDb to add weighted sorting...")
-                item_list = self.weighted_sorting(item_list)
-            else:
-                print(u"Warning: TMDd API key is required "
-                      "for weighted sorting")
-
-        try:
-            new_library = self.plex.server.library.section(
-                self.recipe['new_library']['name'])
-        except:
-            raise Exception("Library '{library}' does not exist".format(
-                library=self.recipe['new_library']['name']))
-
+    def _cleanup_new_library(self, new_library):
+        # Scan the library to clean up the deleted items
+        print(u"Scanning the '{library}' library...".format(
+            library=self.recipe['new_library']['name']))
         new_library.update()
-        # Wait for metadata to finish downloading before continuing
-        print(u"Waiting for metadata to finish downloading...")
+        time.sleep(10)
         new_library = self.plex.server.library.section(
             self.recipe['new_library']['name'])
         while new_library.refreshing:
             time.sleep(5)
             new_library = self.plex.server.library.section(
                 self.recipe['new_library']['name'])
+        new_library.emptyTrash()
+        return new_library.all()
 
-        # Retrieve a list of items from the new library
-        print(u"Retrieving a list of items from the '{library}' library in "
-              u"Plex...".format(library=self.recipe['new_library']['name']))
-        all_new_items = new_library.all()
+    def _pop_imdb_map(self, imdb_map, new_library, i=0):
+        while imdb_map:
+            imdb_id, item = imdb_map.popitem()
+            i += 1
+            print(u"{} {} ({})".format(i, item.title, item.year))
+            self.plex.set_sort_title(
+                new_library.key, item.ratingKey, i, item.title,
+                self.library_type,
+                self.recipe['new_library']['sort_title']['format'],
+                self.recipe['new_library']['sort_title']['visible'])
 
-        # Create a dictionary of {imdb_id: item}
-        imdb_map = {}
-        for m in all_new_items:
-            imdb_id = None
-            tmdb_id = None
-            tvdb_id = None
-            if m.guid is not None and 'imdb://' in m.guid:
-                imdb_id = m.guid.split('imdb://')[1].split('?')[0]
-            elif m.guid is not None and 'themoviedb://' in m.guid:
-                tmdb_id = m.guid.split('themoviedb://')[1].split('?')[0]
-            elif m.guid is not None and 'thetvdb://' in m.guid:
-                tvdb_id = (m.guid.split('thetvdb://')[1]
-                    .split('?')[0]
-                    .split('/')[0])
+    def _run(self):
+        # Get the trakt lists
+        item_list, item_ids = self._get_trakt_lists()
+        force_imdb_id_match = False
+
+        # Get list of items from the Plex server
+        source_libraries = self._get_plex_libraries()
+
+        # Create a list of matching items
+        matching_items, missing_items, matching_total, nonmatching_idx, max_count = self._get_matching_items(
+            source_libraries=source_libraries, item_list=item_list)
+
+        if self.use_playlists:
+            # Start playlist process
+            if self.recipe['new_library']['remove_from_library'] or self.recipe['new_library'].get('remove_old', False):
+                # Start playlist over again
+                self.plex.reset_playlist(playlist_name=self.recipe['new_playlist']['name'], new_items=matching_items)
             else:
-                imdb_id = None
-
-            if imdb_id and str(imdb_id) in item_ids:
-                imdb_map[imdb_id] = m
-            elif tmdb_id and ('tmdb' + str(tmdb_id)) in item_ids:
-                imdb_map['tmdb' + str(tmdb_id)] = m
-            elif tvdb_id and ('tvdb' + str(tvdb_id)) in item_ids:
-                imdb_map['tvdb' + str(tvdb_id)] = m
-            elif force_imdb_id_match:
-                # Only IMDB ID found for some items
-                if tmdb_id:
-                    imdb_id = self.tmdb.get_imdb_id(tmdb_id)
-                elif tvdb_id:
-                    imdb_id = self.tvdb.get_imdb_id(tvdb_id)
-                if imdb_id and str(imdb_id) in item_ids:
-                    imdb_map[imdb_id] = m
-                else:
-                    imdb_map[m.ratingKey] = m
-            else:
-                imdb_map[m.ratingKey] = m
-
-        # Modify the sort titles
-        print(u"Setting the sort titles for the '{}' library...".format(
-            self.recipe['new_library']['name']))
-        if self.recipe['new_library']['sort_title']['absolute']:
-            for i, m in enumerate(item_list):
-                item = imdb_map.pop(m['id'], None)
-                if not item:
-                    item = imdb_map.pop('tmdb' + str(m.get('tmdb_id', '')),
-                                        None)
-                if not item:
-                    item = imdb_map.pop('tvdb' + str(m.get('tvdb_id', '')),
-                                        None)
-                if item:
-                    self.plex.set_sort_title(
-                        new_library.key, item.ratingKey, i + 1, m['title'],
-                        self.library_type,
-                        self.recipe['new_library']['sort_title']['format'],
-                        self.recipe['new_library']['sort_title']['visible'])
+                # Keep existing items
+                self.plex.add_to_playlist(playlist_name=self.recipe['new_playlist']['name'], items=matching_items)
+            playlist_items = self.plex.get_playlist_items(playlist_name=self.recipe['new_playlist']['name'])
+            return missing_items, (len(playlist_items) if playlist_items else 0)
         else:
-            i = 0
-            for m in item_list:
-                item = imdb_map.pop(m['id'], None)
-                if not item:
-                    item = imdb_map.pop('tmdb' + str(m.get('tmdb_id', '')),
-                                        None)
-                if not item:
-                    item = imdb_map.pop('tvdb' + str(m.get('tvdb_id', '')),
-                                        None)
-                if item:
-                    i += 1
-                    self.plex.set_sort_title(
-                        new_library.key, item.ratingKey, i, m['title'],
-                        self.library_type,
-                        self.recipe['new_library']['sort_title']['format'],
-                        self.recipe['new_library']['sort_title']['visible'])
-            while imdb_map:
-                imdb_id, item = imdb_map.popitem()
-                i += 1
-                self.plex.set_sort_title(
-                    new_library.key, item.ratingKey, i, item.title,
-                    self.library_type,
-                    self.recipe['new_library']['sort_title']['format'],
-                    self.recipe['new_library']['sort_title']['visible'])
+            # Start library process
+            # Create symlinks for all items in your library on the trakt watched
+            self._create_symbolic_links(matching_items=matching_items, matching_total=matching_total)
+            # Post-process new library
+            print(u"Creating the '{}' library in Plex...".format(
+                self.recipe['new_library']['name']))
+            new_library, all_new_items = self._verify_new_library_and_get_items(create_if_not_found=True)
+            # Create a dictionary of {imdb_id: item}
+            imdb_map = self._get_imdb_dict(media_items=all_new_items, item_ids=item_ids, force_match=force_imdb_id_match)
+            # Modify the sort titles
+            all_new_items = self._modify_sort_titles_and_cleanup(item_list=item_list, imdb_map=imdb_map, new_library=new_library, sort_only=False)
+            return missing_items, len(all_new_items)
 
+    def _run_sort_only(self):
+        item_list, item_ids = self._get_trakt_lists()
+        force_imdb_id_match = False
+
+        # Get existing library and its items
+        new_library, all_new_items = self._verify_new_library_and_get_items(create_if_not_found=False)
+        # Create a dictionary of {imdb_id: item}
+        imdb_map = self._get_imdb_dict(media_items=all_new_items, item_ids=item_ids, force_match=force_imdb_id_match)
+        # Modify the sort titles
+        _ = self._modify_sort_titles_and_cleanup(item_list=item_list, imdb_map=imdb_map, new_library=new_library, sort_only=True)
         return len(all_new_items)
 
     def run(self, sort_only=False):

--- a/plexlibrary/traktutils.py
+++ b/plexlibrary/traktutils.py
@@ -27,7 +27,7 @@ class Trakt(object):
         self.trakt_core = trakt.core.Core()
 
     def oauth_auth(self):
-        store = False
+        store = True
         self.oauth_token = trakt.core.oauth_auth(
             self.username, client_id=self.client_id,
             client_secret=self.client_secret, store=store)
@@ -59,8 +59,7 @@ class Trakt(object):
         # self.logger.debug('RESPONSE [%s] (%s): %s',
         #     method, url, str(response))
         if response.status_code in self.trakt_core.error_map:
-            if response.status_code == \
-                    trakt.core.errors.OAuthException.http_code:
+            if response.status_code == trakt.core.errors.OAuthException.http_code:
                 # OAuth token probably expired
                 print(u"Trakt OAuth token invalid/expired")
                 self.oauth_auth()

--- a/recipes/examples/movies_trending.yml
+++ b/recipes/examples/movies_trending.yml
@@ -14,12 +14,12 @@ source_list_urls:
 # Source library details
 source_libraries:
   - name: 'Movies'
-    folders:
-      - '/path/to/Movies'
-      - '/path/to/More Movies'
-  - name: 'Different Movies'
-    folders:
-      - '/path/to/Different Movies'
+  - name: 'Movies (4K)'
+
+# New playlist details
+new_playlist:
+  name: 'Trending Movies'
+  remove_from_playlist: true
 
 # New library details
 new_library:


### PR DESCRIPTION
- ``-p`` flag to use playlists rather than libraries for lists, for those who don't want to worry about symbolic links. This also saves time for metadata refreshing. Playlist is created if it doesn't exist; ``remove_from_playlist`` option in config indicates whether user wants to continuously add to the playlist, or purge and recreate it on each refresh.
- Code cleanup in ``recipe.py``. To accommodate for the playlist functionality, I went ahead and broke up the long chain of instructions into smaller functions. Reduces overall line count since most functions are called in both ``run`` and ``run_sort_only``.
- Expanded ``plexutils.py`` file, new methods to assist with playlist creation and modification.
- Removed "source_libraries -> folders" from config. Section paths are now pulled by looking up the section via the Plex API and grabbing all its corresponding paths. This does remove the user's ability to specifically indicate which paths to use for a specific library (for instance, only use two of the four that make up "Movies"); on the flip-side, there should be no user error from an accidental incorrect path in the config.