### PR TITLE
Plex Movie Agent temporary fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ syntax: glob
 .idea/
 config.yml
 recipes/*.yml
+venv/

--- a/plexlibrary/recipe.py
+++ b/plexlibrary/recipe.py
@@ -417,6 +417,7 @@ class Recipe(object):
         # Retrieve a list of items from the new library
         logs.info(u"Retrieving a list of items from the '{library}' library in "
                   u"Plex...".format(library=self.recipe['new_library']['name']))
+
         return new_library, new_library.all()
 
     def _get_imdb_dict(self, media_items, item_ids, force_match=False):
@@ -433,6 +434,11 @@ class Recipe(object):
                 tvdb_id = (m.guid.split('thetvdb://')[1]
                     .split('?')[0]
                     .split('/')[0])
+            elif m.guid is not None and 'plex://' in m.guid:
+                matched_ids = self._get_other_agent_ids_from_plex_movie_agent(m)
+                imdb_id = matched_ids['imdb']
+                tmdb_id = matched_ids['tmdb']
+                tvdb_id = matched_ids['tvdb']
             else:
                 imdb_id = None
 

--- a/plexlibrary/recipe.py
+++ b/plexlibrary/recipe.py
@@ -143,21 +143,23 @@ class Recipe(object):
                 continue
             res = []
             for source_library in source_libraries:
-                # FixMe: This search method cant be used until plexapi is updated to include imdb/tmdb ids
-                """
                 lres = source_library.search(guid='imdb://' + str(item['id']))
                 if not lres and item.get('tmdb_id'):
-                    lres += source_library.search(guid='tmdb://' + str(item['tmdb_id']))
+                    lres += source_library.search(guid='themoviedb://' + str(item['tmdb_id']))
                 if not lres and item.get('tvdb_id'):
-                    lres += source_library.search(guid='tvdb://' + str(item['tvdb_id']))
+                    lres += source_library.search(guid='thetvdb://' + str(item['tvdb_id']))
                 if lres:
                     res += lres
-                """
-                res = source_library.search(title=item['title'], year=item['year'])
-                if not res:
-                    res += source_library.search(title=item['title'], year=int(item['year']) + 1)
-                if not res:
-                    res += source_library.search(title=item['title'], year=int(item['year']) - 1)
+                else:
+                    """
+                    Still no results, fall back to searching by title and 
+                    year because the user may be using the new Plex Movie Agent
+                    """
+                    res = source_library.search(title=item['title'], year=item['year'])
+                    if not res:
+                        res += source_library.search(title=item['title'], year=int(item['year']) + 1)
+                    if not res:
+                        res += source_library.search(title=item['title'], year=int(item['year']) - 1)
 
             if not res:
                 missing_items.append((i, item))
@@ -176,9 +178,8 @@ class Recipe(object):
                     tvdb_id = (r.guid.split('thetvdb://')[1]
                         .split('?')[0]
                         .split('/')[0])
-
-                # FIXME: Temporary workaround until plexapi is updated to include the imdb/tmdb ids
-                if not imdb_id:
+                elif r.guid is not None and 'plex://' in r.guid:
+                    # FIXME: Temporary workaround until plexapi is updated to include the imdb/tmdb ids
                     imdb_id = self._get_imdb_from_plex_movie_agent(r)
 
                 if ((imdb_id and imdb_id == str(item['id']))

--- a/plexlibrary/recipe.py
+++ b/plexlibrary/recipe.py
@@ -201,8 +201,8 @@ class Recipe(object):
                         tvdb_id = matched_ids['tvdb']
 
                     if ((imdb_id and imdb_id == str(item['id']))
-                            or (tmdb_id and tmdb_id == str(item['tmdb_id']))
-                            or (tvdb_id and tvdb_id == str(item['tvdb_id']))):
+                            or (tmdb_id and item.get('tmdb_id') and tmdb_id == str(item['tmdb_id']))
+                            or (tvdb_id and item.get('tvdb_id') and tvdb_id == str(item['tvdb_id']))):
                         if not match:
                             match = True
                             matching_total += 1

--- a/plexlibrary/recipe.py
+++ b/plexlibrary/recipe.py
@@ -138,7 +138,7 @@ class Recipe(object):
                      else self.recipe['new_library'].get('max_count', 0))
 
         if debugging:
-            logs.info(u"Checking {count} items for {max} matches".format(count=len(item_list), max=max_count))
+            logs.info(u"Checking {count} items for {max} max allowed matches.".format(count=len(item_list), max=max_count))
         for i, item in enumerate(item_list):
             match = False
             if 0 < max_count <= matching_total:
@@ -216,6 +216,8 @@ class Recipe(object):
                     logs.info(u"{} {} ({})".format(
                         matching_total, item['title'], item['year']))
             else:
+                if debugging:
+                    logs.info(u"No matches found")
                 missing_items.append((i, item))
                 nonmatching_idx.append(i)
 


### PR DESCRIPTION
A workaround for the new Plex movie agent not returning imdb or tmdb ids.

One downside is that the matching function needs to be reverted to a search based on title and year since the Guid fields no longer contain the imdb/tmdb id (if using the new Plex Agent). This does give the possibility of a miss match but there isn't much that can be done about that.
_Edit:_
_The above downside is only relevant to libraries using the new plex agent, the title/year matching is only used as a fallback if there has been no match found using the imdb/tmdb id method._

This should be removed once the plexapi has been updated to include the required ids.

**Important:**
_The new Plex Movie Agent will only provide the IMDB and TMDB ids if the movie was added to your library or the metadata was refreshed on/after [PMS 1.20.1.3213](https://forums.plex.tv/t/plex-media-server/30447/360)_
