### PR TITLE
Add venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ syntax: glob
 .idea/
 config.yml
 recipes/*.yml
+venv/


### PR DESCRIPTION
Would allow venv to be deployed in the repository folder without causing git conflicts.